### PR TITLE
adding modal forms and peristance of modal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,5 @@ end
 
 gem "acts_as_list"
 gem "view_component"
+
+gem "turbo_power", "~> 0.6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,6 +232,8 @@ GEM
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
+    turbo_power (0.6.1)
+      turbo-rails (>= 1.3.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     view_component (3.11.0)
@@ -276,6 +278,7 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   turbo-rails
+  turbo_power (~> 0.6.1)
   tzinfo-data
   view_component
   web-console

--- a/app/components/forms/button_cancel_modal_component.rb
+++ b/app/components/forms/button_cancel_modal_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Forms::ButtonCancelModalComponent < ApplicationComponent
+  def call
+    render Forms::ButtonCancelComponent.new("#", data: {action: "click->modal#close"})
+  end
+end

--- a/app/components/forms/text_input_component.rb
+++ b/app/components/forms/text_input_component.rb
@@ -8,7 +8,7 @@ class Forms::TextInputComponent < Forms::BaseComponent
   end
 
   def call
-    form.send(method, field, class: input_class, autofocus: @autofocus)
+    form.send(method, field, class: input_class, data: data, autofocus: @autofocus)
   end
 
   private
@@ -19,5 +19,11 @@ class Forms::TextInputComponent < Forms::BaseComponent
 
   def input_class
     class_names("rounded-md w-full disabled:bg-gray-200 relative block appearance-none border border-gray-300 px-1 py-1 text-gray-900 placeholder-gray-500 focus:z-10 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm")
+  end
+
+  def data
+    return {} unless @autofocus
+
+    {controller: "autofocus"}
   end
 end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -29,10 +29,8 @@ class BoardsController < ApplicationController
     respond_to do |format|
       if @board.save
         format.html { redirect_to @board }
-        format.json { render :show, status: :created, location: @board }
       else
         format.html { render :new }
-        format.json { render json: @board.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -43,7 +41,6 @@ class BoardsController < ApplicationController
     respond_to do |format|
       if @board.update(board_params)
         format.html { redirect_to @board }
-        format.json { render :show, status: :ok, location: @board }
       else
         format.html { render :edit }
         format.turbo_stream { render turbo_stream: turbo_stream.replace("board-form", partial: "form", locals: {board: @board, cancel_path: board_path(@board), data: {turbo_frame: :_top}}), status: :unprocessable_entity }

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -45,10 +45,8 @@ class ListsController < ApplicationController
     respond_to do |format|
       if @list.update(list_params)
         format.html { redirect_to board_path(@list.board_id) }
-        format.json { render :show, status: :ok, location: @list }
       else
         format.html { render :edit }
-        format.json { render json: @list.errors, status: :unprocessable_entity }
         format.turbo_stream { render turbo_stream: turbo_stream.replace("list-form", partial: "form", locals: {list: @list, board: @list.board, cancel_path: board_path(@list.board), data: {turbo_frame: :_top}}), status: :unprocessable_entity }
       end
     end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -29,12 +29,12 @@ class TasksController < ApplicationController
 
     respond_to do |format|
       if @task.save
-        format.html { redirect_to @task.board }
-        format.json { render :show, status: :created, location: @task }
+        format.html {
+          redirect_to @task.board
+        }
       else
         format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @task.errors, status: :unprocessable_entity }
-        format.turbo_stream { render turbo_stream: turbo_stream.replace("task-form", partial: "form", locals: {task: @task, board: @task.board, cancel_path: board_path(@task.board), data: {turbo_frame: :_top}}), status: :unprocessable_entity }
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("task-form", partial: "form", locals: {task: @task, board: @task.board, cancel_path: nil, data: {}}), status: :unprocessable_entity }
       end
     end
   end
@@ -45,10 +45,9 @@ class TasksController < ApplicationController
     respond_to do |format|
       if @task.update(task_params)
         format.html { redirect_to @task.board }
-        format.json { render :show, status: :ok, location: @task }
       else
         format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @task.errors, status: :unprocessable_entity }
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("task-form", partial: "form", locals: {task: @task, board: @task.board, cancel_path: nil, data: {}}), status: :unprocessable_entity }
       end
     end
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,6 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+//import * as Turbo from "@hotwired/turbo"
+import TurboPower from "turbo_power"
+TurboPower.initialize(Turbo.StreamActions)

--- a/app/javascript/controllers/autofocus_controller.js
+++ b/app/javascript/controllers/autofocus_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="autofocus"
+export default class extends Controller {
+  connect() {
+    this.element.focus()
+    console.log(this.element)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,8 +4,14 @@
 
 import { application } from "./application"
 
+import AutofocusController from "./autofocus_controller"
+application.register("autofocus", AutofocusController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)
 
 import SortableController from "./sortable_controller"
 application.register("sortable", SortableController)

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ['container'];
+
+  connect() {
+    this.toggleClass = 'hidden';
+    this.element.addEventListener('turbo:submit-end', (event) => {
+      if (event.detail.success && event.detail.fetchResponse.redirected) {
+        console.log(event.detail, "turbo:submit-end success and redirect - make sure closed")
+        this.close(event);
+      }
+    })
+
+  }
+
+  disconnect() {
+    this.close();
+  }
+
+  open() {
+    console.log("open.modal")
+    document.body.classList.add('fixed', 'inset-x-0', 'overflow-hidden');
+    this.containerTarget.classList.remove(this.toggleClass);
+  }
+
+  close(event) {
+    if (typeof event !== 'undefined') {
+      event.preventDefault()
+    }
+    this.containerTarget.classList.add(this.toggleClass);
+  }
+
+  beforeCache() {
+    "this.close();"
+  }
+}

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -19,8 +19,6 @@
     <%= render "lists/list", list: list %>
   <% end %>
   <div class="mr-4 flex max-h-screen flex-shrink-0 flex-col rounded-md bg-gray-200 last:mr-0 filtered" style="width: 20rem;">
-    <%= turbo_frame_tag "new_list" do %>
-      <%= link_to "Add list...", new_board_list_path(@board), class: "w-full flex-shrink-0 block text-base font-normal bg-sky-200 hover:bg-sky-300 px-4 py-2  text-gray-600 rounded-md cursor-pointer transition duration-150 text-left"%>
-    <% end %>
+    <%= link_to "Add list...", new_board_list_path(@board), data: { action: "click->modal#open", turbo_stream: "" }, id: "board-#{@board.id}-add-list", class: "w-full flex-shrink-0 block text-base font-normal bg-sky-200 hover:bg-sky-300 px-4 py-2  text-gray-600 rounded-md cursor-pointer transition duration-150 text-left"%>
   </div>
 </section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
 
   </head>
 
-  <body>
+  <body data-controller="modal">
     <div class="relative pt-14">
       <div class="mx-auto max-w-7xl px-6 lg:px-8">
         <div class="mx-auto max-w-2xl text-center">
@@ -24,5 +24,6 @@
         <%= yield %>
       </div>
     </div>
+    <%= render "shared/modal" %>
   </body>
 </html>

--- a/app/views/lists/_form.html.erb
+++ b/app/views/lists/_form.html.erb
@@ -19,6 +19,7 @@
     <div> 
       <%= render Forms::ButtonSubmitComponent.new() %>    
       <%= render Forms::ButtonCancelComponent.new(cancel_path) if cancel_path %>
+      <%= render Forms::ButtonCancelModalComponent.new() unless cancel_path %>      
     </div>
   </div>
 <% end %>

--- a/app/views/lists/_list.html.erb
+++ b/app/views/lists/_list.html.erb
@@ -1,18 +1,12 @@
 <%= content_tag :div, id: dom_id(list, "div"), data: {id: list.id, sortable_update_url: list_position_path(list) }, class:"mr-4 flex max-h-screen flex-shrink-0 flex-col rounded-md bg-gray-200 px-4 py-2 last:mr-0", style:"width: 20rem;" do %>
-  <%= turbo_frame_tag dom_id(list) do %>
-    <%= link_to list.name, edit_list_path(list), class: "text-lg font-bold text-gray-800 p-4" %>
-  <% end %>
-
+  <%= link_to list.name, edit_list_path(list), data: { action: "click->modal#open", turbo_stream: "" }, id: "list-#{list.id}-edit", class: "text-lg font-bold text-gray-800 p-4" %>
+  
   <ul data-controller="sortable" data-id="<%= list.id %>" data-sortable-group-value="tasks" class="flex-1 flex flex-col content-start overflow-y-auto px-2 py-1" style="padding-left: 0.6rem; padding-right: 0.6rem; padding-bottom: 0.5rem;">
     <% list.tasks.sort_by(&:position).each do |task| %>
       <%= render "tasks/task", task: task %>
     <% end %>
   </ul>
 
-  <%= turbo_frame_tag dom_id(list, "add_task") do %>    
-    <%= link_to "Add task...", new_list_task_path(list), class:"w-full flex-shrink-0 block  text-base text-left font-normal bg-transparent hover:bg-gray-300 text-gray-700 hover:text-gray-900 px-2 py-1 rounded-md" %>
-  <% end %>
-
-
+  <%= link_to "Add task...", new_list_task_path(list), data: { action: "click->modal#open", turbo_stream: "" }, id: "list-#{list.id}-add-task", class:"w-full flex-shrink-0 block  text-base text-left font-normal bg-transparent hover:bg-gray-300 text-gray-700 hover:text-gray-900 px-2 py-1 rounded-md" %>
 <% end %>
 

--- a/app/views/lists/edit.turbo_stream.erb
+++ b/app/views/lists/edit.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.update "modal-title", "Edit list" %>
+<%= turbo_stream.update "modal-body", partial: "form", locals: { list: @list, board: @board, cancel_path: nil, data: {} } %>

--- a/app/views/lists/new.turbo_stream.erb
+++ b/app/views/lists/new.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.update "modal-title", "Add list" %>
+<%= turbo_stream.update "modal-body", partial: "form", locals: { list: @list, board: @board, cancel_path: nil, data: {} } %>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,0 +1,10 @@
+<div data-modal-target="container" id="modal-container" data-turbo-permanent="" class="hidden fixed inset-0 overflow-y-auto flex items-center justify-center" style="z-index: 9999;">
+  <div class="max-w-2xl max-h-screen w-full relative">
+    <div class="m-1 bg-white rounded-lg shadow-lg border-4 border-blue-200">
+      <div class="px-4 py-5 border-b border-gray-200 sm:px-6">
+        <h3 id="modal-title" class="text-lg leading-6 font-medium text-gray-900"></h3>
+      </div>
+      <div id="modal-body" class="px-4 py-2"></div>
+    </div>
+  </div>
+</div>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -19,6 +19,7 @@
     <div> 
       <%= render Forms::ButtonSubmitComponent.new() %>    
       <%= render Forms::ButtonCancelComponent.new(cancel_path) if cancel_path %>
+      <%= render Forms::ButtonCancelModalComponent.new() unless cancel_path %>      
     </div>
   </div>
   <% end %>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,7 +1,3 @@
-
-
-  <%= content_tag :li, id: dom_id(task, "li"), data: { id: task.id, sortable_update_url: task_position_path(task) }, class: "text-lg font-normal leading-tight bg-white py-2 px-3 text-gray-800 border-b border-gray-300 rounded-md mb-3 cursor-pointer hover:bg-gray-100" do %>
-    <%= turbo_frame_tag dom_id(task) do %>
-      <%= link_to task.name, edit_task_path(task) %>
-    <% end %>
+<%= content_tag :li, id: dom_id(task, "li"), data: { id: task.id, sortable_update_url: task_position_path(task) }, class: "text-lg font-normal leading-tight bg-white py-2 px-3 text-gray-800 border-b border-gray-300 rounded-md mb-3 cursor-pointer hover:bg-gray-100" do %>
+  <%= link_to task.name, edit_task_path(task), data: { action: "click->modal#open", turbo_stream: "" }, id: "task-#{task.id}-edit" %>
 <% end %>

--- a/app/views/tasks/edit.turbo_stream.erb
+++ b/app/views/tasks/edit.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.update "modal-title", "Edit task" %>
+<%= turbo_stream.update "modal-body", partial: "form", locals: { task: @task, cancel_path: nil, data: {} } %>

--- a/app/views/tasks/new.turbo_stream.erb
+++ b/app/views/tasks/new.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.update "modal-title", "Add task" %>
+<%= turbo_stream.update "modal-body", partial: "form", locals: { task: @task, cancel_path: nil, data: {} } %>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "postcss": "^8.4.38",
     "sortablejs": "^1.15.2",
     "tailwindcss": "^3.4.3",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "turbo_power": "^0.6.1"
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets",

--- a/test/components/forms/button_cancel_modal_component_test.rb
+++ b/test/components/forms/button_cancel_modal_component_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Forms::ButtonCancelModalComponentTest < ViewComponent::TestCase
+  def test_component_renders_something_useful
+    # assert_equal(
+    #   %(<span>Hello, components!</span>),
+    #   render_inline(Forms::ButtonCancelModalComponent.new(message: "Hello, components!")).css("span").to_html
+    # )
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,6 +969,11 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
+turbo_power@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/turbo_power/-/turbo_power-0.6.1.tgz#e0ca3a7cfdaaad57c2b780617851761b65b0375b"
+  integrity sha512-OVHTgaYvvFrYnVE/vfw9u+17ipQrXqNlUcaZ2lkVCBfsEdgZv00fmCv/dOH8ilKRFzrcP+tK3Yl2pMZGbui+4g==
+
 update-browserslist-db@^1.0.13:
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz#3c5e4f5c083661bd38ef64b6328c26ed6c8248c4"


### PR DESCRIPTION
in the previous version because of broadcast_refreshes if you had the editor open on another browser and submitted a form the refresh triggered on the other browser would close the editor. 

you can still see this effect if editing the board. This is also a problem on this [demo](https://github.com/basecamp/turbo-8-morphing-demo/tree/page-refreshes) project from 37signals.

decided first to change the editing of tasks and lists to a modal using turbo streams to put in the form. On that modal, it has ```data-turbo-permanent="" ``` tag so it stays. 

Then had to work out how to close the modal on the save added this to my stimulus modal controller that checks if was redirected and successful which means the modal closes and the rest of the page morphs.
```
    this.element.addEventListener('turbo:submit-end', (event) => {
      if (event.detail.success && event.detail.fetchResponse.redirected) {
        console.log(event.detail, "turbo:submit-end success and redirect - make sure closed")
        this.close(event);
      }
    })
```

It means if the user has a modal open on there browser the underlying screen will refresh but they won't lose there modal. 