### PR TITLE
fixing some snags

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -4,7 +4,7 @@ class BoardsController < ApplicationController
   # GET /boards
   # GET /boards.json
   def index
-    @boards = Board.all
+    @boards = Board.all.order(:name)
   end
 
   # GET /boards/1

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -27,7 +27,7 @@ class ListsController < ApplicationController
   # POST /lists
   # POST /lists.json
   def create
-    @list = @board.lists.new(list_params)
+    @list = @board.lists.new(create_list_params)
 
     respond_to do |format|
       if @list.save
@@ -43,7 +43,7 @@ class ListsController < ApplicationController
   # PATCH/PUT /lists/1.json
   def update
     respond_to do |format|
-      if @list.update(list_params)
+      if @list.update(update_list_params)
         format.html { redirect_to board_path(@list.board_id) }
       else
         format.html { render :edit }
@@ -74,7 +74,11 @@ class ListsController < ApplicationController
   end
 
   # Only allow a list of trusted parameters through.
-  def list_params
+  def create_list_params
     params.require(:list).permit(:name, :position)
+  end
+
+  def update_list_params
+    params.require(:list).permit(:name)
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -25,7 +25,7 @@ class TasksController < ApplicationController
   # POST /tasks
   # POST /tasks.json
   def create
-    @task = Task.new(task_params)
+    @task = Task.new(create_task_params)
 
     respond_to do |format|
       if @task.save
@@ -43,7 +43,7 @@ class TasksController < ApplicationController
   # PATCH/PUT /tasks/1.json
   def update
     respond_to do |format|
-      if @task.update(task_params)
+      if @task.update(update_task_params)
         format.html { redirect_to @task.board }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -70,7 +70,11 @@ class TasksController < ApplicationController
   end
 
   # Only allow a list of trusted parameters through.
-  def task_params
+  def create_task_params
     params.require(:task).permit(:name, :list_id, :position)
+  end
+
+  def update_task_params
+    params.require(:task).permit(:name)
   end
 end

--- a/app/javascript/controllers/autofocus_controller.js
+++ b/app/javascript/controllers/autofocus_controller.js
@@ -3,7 +3,12 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="autofocus"
 export default class extends Controller {
   connect() {
-    this.element.focus()
-    console.log(this.element)
+    setTimeout(() => {
+      this.element.focus()
+      const length = this.element.value.length;
+      this.element.setSelectionRange(length, length);
+    }, 0);
+
+    console.log("autofocus", this.element)
   }
 }


### PR DESCRIPTION
Small Fixes
1. Order Boards By Name
2. On the modal for task and list when doing an update only permit name change so if someone else has reordered we do not revert their order.
3. Make changes to the autofocus controller so it works more consistently and puts the cursor to the end of the input box.